### PR TITLE
clean up debug logging and only run template validation on the template repo

### DIFF
--- a/.github/workflows/template-validation.yml
+++ b/.github/workflows/template-validation.yml
@@ -18,12 +18,27 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Check if this is the template repository
+        id: repo_check
+        run: |
+          echo "Repository: $GITHUB_REPOSITORY"
+          if [[ "$GITHUB_REPOSITORY" == *"/SwiftProjectTemplate" ]]; then
+            echo "✅ This is the SwiftProjectTemplate repository - proceeding with validation"
+            echo "is_template_repo=true" >> $GITHUB_OUTPUT
+          else
+            echo "ℹ️  This is a generated project repository - skipping template validation"
+            echo "💡 Template validation only runs on the SwiftProjectTemplate repository"
+            echo "is_template_repo=false" >> $GITHUB_OUTPUT
+          fi
+
       - name: Set up Xcode
+        if: steps.repo_check.outputs.is_template_repo == 'true'
         uses: maxim-lobanov/setup-xcode@v1
         with:
           xcode-version: "16.0"
 
       - name: Cache Homebrew packages
+        if: steps.repo_check.outputs.is_template_repo == 'true'
         uses: actions/cache@v4
         with:
           path: |
@@ -34,6 +49,7 @@ jobs:
             ${{ runner.os }}-homebrew-
 
       - name: Install dependencies
+        if: steps.repo_check.outputs.is_template_repo == 'true'
         run: |
           # Install Homebrew dependencies
           brew bundle install --file=./Brewfile
@@ -46,6 +62,7 @@ jobs:
           yq --version
 
       - name: Generate test project
+        if: steps.repo_check.outputs.is_template_repo == 'true'
         run: |
           echo "🏗️ Generating test project for E2E validation..."
           echo "Working directory: $(pwd)"
@@ -58,22 +75,10 @@ jobs:
           echo "Running setup script from template root directory"
           echo "Target directory: $(pwd)/ci-test-project"
 
-          set -x  # Enable verbose output
           cd ci-test-project
 
-          echo "🔍 Debugging setup script execution..."
-          echo "Current directory: $(pwd)"
-          echo "Setup script location: $(ls -la scripts/setup.sh)"
-          echo "Setup script is executable: $(test -x scripts/setup.sh && echo 'YES' || echo 'NO')"
-
-          # Check if all required tools are available
-          echo "🔧 Checking tool availability..."
-          which bash || echo "bash not found"
-          bash --version || echo "bash version check failed"
-
-          # Run setup script with bash debugging and verbose output
-          echo "🚀 Running setup script with full debugging..."
-          bash -x ./scripts/setup.sh \
+          echo "🚀 Running setup script to generate test project..."
+          ./scripts/setup.sh \
             --project-name "CITestApp" \
             --bundle-id-root "com.ci.test" \
             --deployment-target 18.0 \
@@ -84,26 +89,18 @@ jobs:
             --no-commit \
             --public \
             --skip-brew \
-            --force 2>&1 || {
+            --force || {
               echo "❌ Setup script failed with exit code $?"
-              echo ""
-              echo "📁 Contents of current directory:"
-              ls -la
-              echo ""
-              echo "📁 Contents of parent directory:"
-              ls -la ..
-              echo ""
-              echo "📝 Setup script contents (first 50 lines):"
-              head -50 scripts/setup.sh
+              echo "💡 For detailed debugging, enable ACTIONS_STEP_DEBUG in repository settings"
               exit 1
             }
-          set +x  # Disable verbose output
 
           echo "✓ Test project generated successfully"
           echo "Generated files:"
           ls -la
 
       - name: Run E2E validation on generated project
+        if: steps.repo_check.outputs.is_template_repo == 'true'
         run: |
           echo "🔍 Running end-to-end validation on generated project..."
           cd ci-test-project
@@ -115,13 +112,14 @@ jobs:
           echo "✓ E2E validation completed successfully"
 
       - name: Cleanup test project
-        if: always()
+        if: always() && steps.repo_check.outputs.is_template_repo == 'true'
         run: |
           echo "🧹 Cleaning up test project..."
           rm -rf ci-test-project
           echo "✓ Cleanup completed"
 
       - name: Template validation summary
+        if: steps.repo_check.outputs.is_template_repo == 'true'
         run: |
           echo "🎉 Template Validation Complete!"
           echo ""
@@ -130,3 +128,18 @@ jobs:
           echo "✅ E2E workflow validated"
           echo ""
           echo "Template is ready for use! 🚀"
+
+      - name: Generated repository info
+        if: steps.repo_check.outputs.is_template_repo == 'false'
+        run: |
+          echo "🎉 Welcome to your new iOS project!"
+          echo ""
+          echo "This repository was created from SwiftProjectTemplate."
+          echo "Template validation is skipped for generated projects."
+          echo ""
+          echo "📖 Next steps:"
+          echo "  1. Run './scripts/setup.sh' to configure your project"
+          echo "  2. Follow the README.md for development guidance"
+          echo "  3. Start building your iOS app!"
+          echo ""
+          echo "✨ Happy coding! 🚀"


### PR DESCRIPTION
## Summary

clean up verbose logging and only run the template validation when checking PRs from the template repo.

## Changes

- Only use verbose logging when ACTIONS_STEP_DEBUG is enabled and log to GITHUB_OUTPUT
- skip template validation CI if GITHUB_REPOSITORY == "/SwiftProjectTemplate"

## Type of Change

<!-- Check the relevant option -->
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [x] 🔧 Configuration change
- [ ] ♻️ Code refactoring
- [x] 🧪 Test improvements
- [ ] 🔒 Security update

## Testing

- [x] Unit tests pass (`./scripts/test.sh`)
- [x] UI tests pass (`./scripts/test.sh --ui`)
- [x] Manual testing completed
- [x] Code builds successfully (`./scripts/build.sh`)
- [x] Linting passes (`./scripts/lint.sh`)
- [x] Formatting is correct (`./scripts/format.sh`)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

