### PR TITLE
restore xcode 26 and swift 6.2 defaults

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -12,8 +12,8 @@ source "$(dirname "${BASH_SOURCE[0]}")/_helpers.sh"
 
 # Default values
 PROJECT_NAME=""
-DEPLOYMENT_TARGET="18.0"
-SWIFT_VERSION="5.10"
+DEPLOYMENT_TARGET="26.0"
+SWIFT_VERSION="6.2"
 PROJECT_TYPE="private"  # private or public
 BUNDLE_ID_ROOT="com.yourcompany"
 TEST_FRAMEWORK="swift-testing"  # swift-testing or xctest
@@ -314,7 +314,7 @@ prompt_for_missing_info() {
       DEPLOYMENT_TARGET="$input_deployment_target"
       if ! validate_ios_version "$DEPLOYMENT_TARGET"; then
         log_error "Invalid deployment target format. Using default: $DEPLOYMENT_TARGET"
-        DEPLOYMENT_TARGET="18.0"
+        DEPLOYMENT_TARGET="26.0"
       fi
     fi
   fi
@@ -327,7 +327,7 @@ prompt_for_missing_info() {
       SWIFT_VERSION="$input_swift_version"
       if ! validate_swift_version "$SWIFT_VERSION"; then
         log_error "Invalid Swift version format. Using default: $SWIFT_VERSION"
-        SWIFT_VERSION="5.10"
+        SWIFT_VERSION="6.2"
       fi
     fi
   fi


### PR DESCRIPTION
## Summary

Accidentally reverted defaults to Xcode 16.0 and Swift 5.10. Restoring Xcode 26.0 and Swift 6.2 defaults.

## Changes

- fixed setup.sh to use Xcode 26.0 and Swift 6.2

## Type of Change

<!-- Check the relevant option -->
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Configuration change
- [ ] ♻️ Code refactoring
- [ ] 🧪 Test improvements
- [ ] 🔒 Security update

## Testing

- [x] Unit tests pass (`./scripts/test.sh`)
- [x] UI tests pass (`./scripts/test.sh --ui`)
- [x] Manual testing completed
- [x] Code builds successfully (`./scripts/build.sh`)
- [x] Linting passes (`./scripts/lint.sh`)
- [x] Formatting is correct (`./scripts/format.sh`)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

 